### PR TITLE
Fix Layer.mask method parameter and return type documentation

### DIFF
--- a/docs/layer/sub-objects.md
+++ b/docs/layer/sub-objects.md
@@ -97,14 +97,14 @@ The `index` value will have After Effects finds the mask by its index in the Tim
 +-----------+--------+------------------------------+
 | Parameter |  Type  |         Description          |
 +===========+========+==============================+
-| `name`    | String | Effect name or index to get. |
+| `name`    | String | Mask name or index to get.   |
 |           |        |                              |
 | `index`   | Number |                              |
 +-----------+--------+------------------------------+
 
 #### Returns
 
-[Effect](../objects/effect.md)
+[Mask](../objects/mask.md)
 
 #### Example
 


### PR DESCRIPTION
Revised the Layer’s mask method documentation by updating the parameter and return type from "Effect" to "Mask".