### PR TITLE
Add new APIs in 26.0 Beta

### DIFF
--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -4,6 +4,21 @@ What's new and changed for expressions?
 
 ---
 
+## [After Effects 26.0 (Beta)](https://helpx.adobe.com/after-effects/using/whats-new.html) (November 2025)
+
+- Added: Expression access to variable font axes through text animators
+    - Added: [Variable Font Axes](../text/variable-fonts.md) - Access variable font axes (Weight, Width, Slant, etc.) via `text.animator("Animator Name").property.fontAxis[Tag]`
+- Added: Property methods for finding neighboring keyframes and markers
+    - Added: [Property.previousKey()](../objects/property.md#previouskey)
+    - Added: [Property.nextKey()](../objects/property.md#nextkey)
+- Added: Expression access to dropdown menu text strings
+    - Added: [Dropdown Menus](../objects/dropdown.md)
+        - Added: [Dropdown Menu.items](../objects/dropdown.md#items)
+        - Added: [Dropdown Menu.text](../objects/dropdown.md#text)
+        - Added: [Dropdown Menu.textAtTime()](../objects/dropdown.md#textattime)
+
+---
+
 ## [After Effects 25.0](https://helpx.adobe.com/after-effects/using/whats-new/2025.html) (October 2024)
 
 Added many new text style properties and methods for both characters and paragraphs, as well as the ability to control per-character styling through expressions.

--- a/docs/objects/dropdown.md
+++ b/docs/objects/dropdown.md
@@ -1,0 +1,99 @@
+# Dropdown Menus
+
+This category contains information relating to dropdown menu properties.
+
+!!! note
+    These APIs were added in After Effects (Beta) 26.0 and are subject to change while they remain in Beta.
+
+In expressions, the `.value` of a dropdown menu is returned as an index (a number). This is true of both customized Menu properties of Dropdown Menu Controls and dropdown menus of other effects and layers. **The strings in dropdown menu properties of effects and layers are also accessible via the properties/methods below.**
+
+On this page, `effect("Dropdown Menu Control")("Menu")` is used as a sample on how to call these items; however, note that any method that returns a dropdown menu [Property](../objects/property.md) will work.
+
+**Notes**
+
+- These APIs are available only in expressions using the JavaScript expression engine.
+
+- The text of `Layer Control` dropdowns is not accessible with these APIs. If you need the selected layer's name, you can use the `.name` property of the layer returned by the Layer Control.
+
+!!! warning
+    We recommend continuing to use the index of dropdown menus when driving expression logic (versus matching the strings), since indexes will remain unchanged when the language of After Effects changes.
+
+---
+
+## Attributes
+
+### items
+
+`effect("Dropdown Menu Control")("Menu").items`
+
+#### Description
+
+Returns an array of all the text strings in a dropdown menu property.
+
+#### Type
+
+Array of Strings
+
+#### Example
+
+**Show all the strings in a dropdown on separate lines:**
+
+```js
+const menu = effect("Dropdown Menu Control")("Menu");
+const allStrings = menu.items;
+
+allStrings.join("\n");
+```
+
+---
+
+### text
+
+`effect("Dropdown Menu Control")("Menu").text`
+
+#### Description
+
+Returns the currently-active text string of a dropdown menu property at the current time.
+
+#### Type
+
+String
+
+#### Example
+
+**Show the selected dropdown text directly in a Text layer:**
+
+```js
+effect("Dropdown Menu Control")("Menu").text;
+```
+
+**Show the current Fractal Type from the native Fractal Noise effect:**
+
+```js
+effect("ADBE Fractal Noise")("ADBE Fractal Noise-0001").text;
+```
+
+---
+
+## Methods
+
+### textAtTime()
+
+`effect("Dropdown Menu Control")("Menu").textAtTime(time)`
+
+#### Description
+
+Returns the text string of a dropdown menu property at the specified time, in seconds.
+
+This is effectively the same as how `valueAtTime()` relates to `value`, in that `text` will always return the dropdown string as the current time, and `timeAtTime()` can return the string at a specific time.
+
+#### Parameters
+
+| Parameter |  Type  |                    Description                    |
+| --------- | ------ | ------------------------------------------------- |
+| `time`    | Number | The time, in seconds, to get the text string from |
+
+#### Returns
+
+String
+

--- a/docs/objects/property.md
+++ b/docs/objects/property.md
@@ -336,6 +336,69 @@ twoSecondKey.value;
 
 ---
 
+### nextKey()
+
+`thisLayer.position.nextKey(time)`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+Returns the keyframe or marker after the specified time. If the specified time is after the last keyframe or marker, returns the last keyframe or marker.
+
+This method is available only in expressions using the JavaScript expression engine.
+
+#### Parameters
+
+| Parameter |  Type  |                    Description                    |
+| --------- | ------ | ------------------------------------------------- |
+| `time`    | Number | The time, in seconds, to find the next key from |
+
+#### Returns
+
+Key or MarkerKey
+
+---
+
+### previousKey()
+
+`thisLayer.position.previousKey(time)`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+Returns the keyframe or marker at or before the specified time. If none exist before the specified time, returns the first keyframe or marker.
+
+This method is available only in expressions using the JavaScript expression engine.
+
+#### Parameters
+
+| Parameter |  Type  |                      Description                      |
+| --------- | ------ | ------------------------------------------------------ |
+| `time`    | Number | The time, in seconds, to find the previous key from |
+
+#### Returns
+
+Key or MarkerKey
+
+#### Example
+
+**Trigger property's keyframes at each layer marker:**
+
+```js
+const animDuration = key(numKeys).time - key(1).time;
+const animTime = time - marker.previousKey(time).time;
+
+const animRemap = linear(animTime, 0, animDuration, key(1).time, key(numKeys).time);
+
+valueAtTime(animRemap);
+```
+
+---
+
 ### propertyGroup()
 
 `thisLayer.position.propertyGroup([countUp=1])`

--- a/docs/text/variable-fonts.md
+++ b/docs/text/variable-fonts.md
@@ -1,0 +1,44 @@
+# Variable Font Axes
+
+`text.animator("Animator Name").property.fontAxis[Tag]`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+Variable font axes can be accessed in expressions through Text Animator groups. Each added axis is accessed using the pattern `fontAxis[Tag]` where `Tag` is the **4-character axis tag**. 
+
+The axis tag is a 4-character identifier (e.g., `Wght` for Weight, `Wdth` for Width). See list below for common identifiers.
+
+#### Common Axis Tags
+
+- `fontAxisWght` - Weight
+- `fontAxisWdth` - Width
+- `fontAxisSlnt` - Slant
+- `fontAxisItal` - Italic
+- `fontAxisOpsz` - Optical Size
+
+Returns the value of a variable font axis property from a text animator.
+
+!!! note
+    Axes must exist on the variable font to have any effect. Fonts may also include custom axes with 4-character uppercase tags.
+
+#### Type
+
+[Property](../objects/property.md) (Number)
+
+---
+
+## Examples
+
+Reference a variable font axis from another property:
+
+```js
+text.animator("Animator 1").property.fontAxisWght
+```
+
+Link layer opacity to font weight:
+
+```js
+const weight = text.animator("Animator 1").property.fontAxisWght;
+weight / 10;
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
         - Effect: objects/effect.md
         - Mask: objects/mask.md
         - Property: objects/property.md
+        - Dropdown Menus: objects/dropdown.md
         - Marker Property: objects/marker-property.md
         - Path Property: objects/path-property.md
         - Key: objects/key.md
@@ -48,6 +49,7 @@ nav:
         - Text: text/text.md
         - Source Text: text/sourcetext.md
         - Text Style: text/style.md
+        - Variable Fonts: text/variable-fonts.md
 
 #### Additional config below - modify sparingly!
 


### PR DESCRIPTION
This PR adds documentation for new expression APIs added in the 26.0 Beta in November 2025.

- Variable font axes
- Reading strings from Dropdown Menus
- New previousKey and nextKey methods

All new APIs are noted as Beta-only and subject to potential changes while still in Beta. These docs will be updated to reflect any changes.